### PR TITLE
Clean up $events when *off* is called.

### DIFF
--- a/tiny-eventer.js
+++ b/tiny-eventer.js
@@ -44,6 +44,11 @@ function Eventer() {
         this.$events[eventName] = (this.$events[eventName] || []).filter(function (eventItem) {
             return ![eventItem.listener === _listener, eventItem._this === __this].some(function (condition) { return condition; });
         });
+
+        // Delete the property if there are no more listeners on it
+        if (this.$events[eventName].length < 1) {
+            delete this.$events[eventName];
+        }
     }.bind(this);
 
 


### PR DESCRIPTION
When the last listener of an event is removed, the property too is removed from this.$events.

This solves #4 
